### PR TITLE
Fix README.md badge src link

### DIFF
--- a/generators/app/templates/_README.md
+++ b/generators/app/templates/_README.md
@@ -1,5 +1,5 @@
 # <%= name %> OpenAPI Specification
-[![Build Status](https://travis-ci.org/<%= repo %>.svg?branch=master)](https://travis-ci.org/<%= repo %>)
+[![Build Status](https://travis-ci.com/<%= repo %>.svg?branch=master)](https://travis-ci.org/<%= repo %>)
 
 ## Steps to finish
 


### PR DESCRIPTION
Links in the instruction lead to travis.COM but the status badge at the top links to travis.ORG, which (I suppose) is incorrect.