### PR TITLE
fix: Use openapi-cli v0.8.0 minimum

### DIFF
--- a/lib/migrate-2-3.js
+++ b/lib/migrate-2-3.js
@@ -257,7 +257,7 @@ function migratePackageJson() {
   const packageJson = readYaml('package.json');
   packageJson.dependencies = packageJson.dependencies || {};
   delete packageJson.dependencies['swagger-repo'];
-  packageJson.dependencies['@redocly/openapi-cli'] = '^0.7.0';
+  packageJson.dependencies['@redocly/openapi-cli'] = '^0.8.0';
 
   packageJson.scripts = packageJson.scripts || {};
 


### PR DESCRIPTION
This fixes the issue I had when I tested the migration script.