### PR TITLE
template(openapi): fix typo

### DIFF
--- a/template/openapi/README.md
+++ b/template/openapi/README.md
@@ -1,12 +1,12 @@
 ## The `openapi` folder
 
-This folder contains your entrypoint `openapi.yaml`. 
+This folder contains your entrypoint `openapi.yaml`.
 
 That file contains references to the entire API definition.
 
 Here are some sections to pay attention to:
 
-* Top-level **description**: this accepts markdown, and Redoc and Redocly API Reference will render it at the top of the docs.  Consider maintaining your markdown in a separate file and [embedding it](https://docs.redoc.ly/api-reference-dics/embedded-markdown/). Note to Redoc community edition users, the special tags are only available to the Redocly API Reference users, but you can still embed markdown.
+* Top-level **description**: this accepts markdown, and Redoc and Redocly API Reference will render it at the top of the docs.  Consider maintaining your markdown in a separate file and [embedding it](https://docs.redoc.ly/api-reference-docs/embedded-markdown/). Note to Redoc community edition users, the special tags are only available to the Redocly API Reference users, but you can still embed markdown.
 * Security schemes: you will define the scheme(s) your API uses for security (eg OAuth2, API Key, etc...). The security schemes are used by the Redocly API Reference "Try It" API console feature.
 * [Paths](paths/README.md): this defines each endpoint.  A path can have one operation per http method.
 * Tags: it's a good idea to organize each operation.  Each tag can have a description.  The description is used as a section description within the reference docs.


### PR DESCRIPTION
This PR fixes a typo in the README template of the openapi README.

With this fix the link to https://docs.redoc.ly/api-reference-docs/embedded-markdown/ is working again