### PR TITLE
Fix malformatted yaml

### DIFF
--- a/template/.redocly.yaml.ejs
+++ b/template/.redocly.yaml.ejs
@@ -1,6 +1,6 @@
 # See https://docs.redoc.ly/cli/configuration/ for more information.
 apiDefinitions:
-  main: "<%= mainDefinitionFile %>"
+  main: <%= mainDefinitionFile %>
 lint:
   rules:
     no-unused-schemas: warning


### PR DESCRIPTION
Fixes "YAMLException: unknown escape sequence at line 3, column 18:", because the .redocly.yaml configuration is written without quotation marks (See here: https://docs.redoc.ly/cli/configuration/)