### PR TITLE
fix: use forward slashes on $ref paths generated on windows

### DIFF
--- a/lib/migrate-2-3.js
+++ b/lib/migrate-2-3.js
@@ -13,6 +13,7 @@ const {
   traverseFolderDeep,
   replace$Refs,
   implicitlyReferenceDiscriminator,
+  ensureForwardSlashesInPath,
   OPENAPI3_COMPONENTS,
   OPENAPI3_METHODS
 } = require('./utils');
@@ -96,7 +97,7 @@ module.exports = async function migrate() {
     const encodedPath = basename(file, '.yaml');
     const path = encodedPath.replace(/@/g, '/');
     paths['/' + path] = {
-      $ref: './' + join('paths', file)
+      $ref: ensureForwardSlashesInPath('./' + join('paths', file))
     };
 
     const pathData = readYaml(join('spec/paths', file));

--- a/lib/split-definition.js
+++ b/lib/split-definition.js
@@ -10,6 +10,7 @@ const {
   implicitlyReferenceDiscriminator,
   replace$Refs,
   traverseFolderDeep,
+  ensureForwardSlashesInPath,
   OPENAPI3_COMPONENTS,
   OPENAPI3_METHODS
 } = require('./utils');
@@ -69,7 +70,7 @@ module.exports = function(openapi, openapiDir) {
 
       writeYaml(pathData, pathFile);
       openapi.paths[oasPath] = {
-        $ref: path.relative(openapiDir, pathFile)
+        $ref: ensureForwardSlashesInPath(path.relative(openapiDir, pathFile))
       };
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -226,6 +226,11 @@ function crawl(object, visitor) {
   }
 }
 
+/**
+ * Convert Windows backslash paths to slash paths: foo\\bar ➔ foo/bar
+ * Copied form openapi-cli: 
+ * https://github.com/Redocly/openapi-cli/blob/b389661f91202174d5c46766ef2be73bfe9faf0d/packages/core/src/utils.ts#L161
+ */
 exports.ensureForwardSlashesInPath = (path) => {
   const isExtendedLengthPath = /^\\\\\?\\/.test(path)
   if (isExtendedLengthPath) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -225,3 +225,12 @@ function crawl(object, visitor) {
     crawl(object[key], visitor);
   }
 }
+
+exports.ensureForwardSlashesInPath = (path) => {
+  const isExtendedLengthPath = /^\\\\\?\\/.test(path)
+  if (isExtendedLengthPath) {
+    return path
+  }
+
+  return path.replace(/\\/g, '/');
+}


### PR DESCRIPTION
## What/Why/How?

The `$ref`s should be generated with forward slashes on all platrofms

## Reference

Fixes https://github.com/Redocly/create-openapi-repo/issues/81

## Screenshots
![image](https://user-images.githubusercontent.com/22818316/158454074-5940e2ba-5f48-4d67-8895-51518aa30553.png)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines